### PR TITLE
Add unit test for cancel_document_run client method

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -146,3 +146,19 @@ def test_add_files_to_document(monkeypatch):
     assert captured["endpoint"] == "/document/doc-1/files/upload"
     assert captured["params"] == {"type": "input"}
     assert captured["files"][0][0] == "files"
+
+
+def test_cancel_document_run(monkeypatch):
+    clerk = Clerk(api_key="token")
+    captured: Dict[str, Any] = {}
+
+    def fake_post(self: Clerk, endpoint: str):
+        captured.update(endpoint=endpoint)
+        return StandardResponse(data=[make_document_payload(id="doc-7")])
+
+    monkeypatch.setattr(Clerk, "post_request", fake_post)
+
+    document = clerk.cancel_document_run("doc-7")
+
+    assert captured["endpoint"] == "/document/doc-7/cancel"
+    assert document.id == "doc-7"


### PR DESCRIPTION
## Summary
- add coverage for Clerk.cancel_document_run by verifying the POST endpoint and returned document id

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69159b5b5abc832bb7e92b45066395aa)